### PR TITLE
Change the close button behavior and bump the version to 0.2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, Yuhsiang M. Tsai
+Copyright (c) 2022 - 2025, Yu-Hsiang M. Tsai
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # KeepZotero (Zotero 7)
-KeepZotero is a zotero plugin to keep zotero in taskbar by changing remap the key to minimize or give a confirmation dialog before close.  
+KeepZotero is a zotero plugin to keep zotero in taskbar by remapping the key or changing the button behavior to minimize or give a confirmation dialog before close.  
 The master branch and version 0.1.0 starts to support Zotero 7.  
 For the user from Zotero 6. Please check [Changes from Zotero 6 to Zotero 7](#changes-from-zotero-6-to-zotero-7)
 
@@ -14,18 +14,19 @@ If you still want to use KeepZotero in Zotero 6, please check [tag v0.0.2](https
 4. choose the xpi file
 
 # Changes from Zotero 6 to Zotero 7
-This plugin does not change the behavior of close button anymore.  
-This plugin can remap the common exit key (`Ctrl/Command + W`, `Ctrl+ Q`, `Alt + F4`) to just minimize Zotero
+- This plugin can remap the common exit key (`Ctrl/Command + W`, `Ctrl+ Q`, `Alt + F4`) to just minimize Zotero.
+- This new plugin (v0.2.0) can change the close button behavior to minmize the accident of closing Zotero.
 
 # Usage
 There are some options to decide KeepZotero's behavior
 When Zotero is minimized, close from taskbar terminates Zotero.
-1. (Default: Yes) Give a confirmation dialog when closing Zotero. If it is selected, user need to confirm exit to close Zotero. If Alt + F4 still performs `close`, it will not trigger the confirmation dialog. (Unstable, especially MacOS)
-2. (Default: yes) Make shortcut Ctrl/Command + W to be minimization
+1. (Default: Yes) Change the close button of the title bar to minimize the window.
+2. (Default: Yes) Give a confirmation dialog when closing Zotero. If it is selected, user need to confirm exit to close Zotero. If Alt + F4 still performs `close`, it will not trigger the confirmation dialog. (Unstable, especially MacOS)
+3. (Default: yes) Make shortcut Ctrl/Command + W to be minimization
 Note. this shortcut still works on pdf reader or other place out of the main panel.
 The followings only have effect on Windows or Linux:
-3. (Default: yes) Make shortcut Alt + F4 to be minimization
-4. (Default: yes) Make shortcut Ctrl + Q to be minimization Note. MacOS Command + Q always closes entire Zotero.
+4. (Default: yes) Make shortcut Alt + F4 to be minimization
+5. (Default: yes) Make shortcut Ctrl + Q to be minimization Note. MacOS Command + Q always closes entire Zotero.
 
 # Different keyboard layout
 If the current shortcut is not your usual shortcut (not the personal shortcut) to close the panel, please create an issue with the shortcut.
@@ -36,4 +37,4 @@ If the current shortcut is not your usual shortcut (not the personal shortcut) t
 
 # My Limitation and Questions
 Although I have some coding experience with different language, I do not learn JavaScript or Chrome Extension(?). Thus, the code may do some stupid things... When developing this plugin, I do not find the proper documentation to explain my questions, which I write them in the code. I will appreciate if someone notice any issue inside the code or have some answer to my questions.
-- I do not find a way to detect the close button. The close event I used in KeepZotero for Zotero 6 does not work in Zotero 7.
+- I do not find a way to detect the close event, which I used in KeepZotero for Zotero 6 does not work in Zotero 7. Currently, I add a event to the close button of title bar to change the behavior. It only changes the close button, so close functionality from the taskbar is not changed. 

--- a/keepzotero-update.json
+++ b/keepzotero-update.json
@@ -3,9 +3,9 @@
     "keepzotero@yhmtsai": {
       "updates": [
         {
-          "version": "0.1.0",
-          "update_link": "https://github.com/yhmtsai/KeepZotero/releases/download/v0.1.0/keepzotero-0.1.0-fx.xpi",
-          "update_hash": "sha256:c49732fc60c051014a0fd5aeb943224401343a42200801d2156defc0753423c2",
+          "version": "0.2.0",
+          "update_link": "https://github.com/yhmtsai/KeepZotero/releases/download/v0.2.0/keepzotero-0.2.0-fx.xpi",
+          "update_hash": "sha256:2b2341b122bbacb115e72ecd38aedaf89e5e0691490c187995ffea5c73ff799c",
           "applications": {
             "zotero": {
               "strict_min_version": "6.999"

--- a/locale/en-US/keepzotero/preferences.ftl
+++ b/locale/en-US/keepzotero/preferences.ftl
@@ -1,7 +1,9 @@
 keepzotero-preferences = KeepZotero Preferences
+keepzotero-cb_minimize_on_button=
+    .label = Clicking the close button of titlebar will minimize the window.
 keepzotero-cb_check_exit = 
     .label = Give a confirmation dialog when closing Zotero. When Alt + F4 gives close, it will not trigger confirmation dialog.
-keepzotero-note = Note. This plugin does not change behavior of the close button or close from the menu.
+keepzotero-note = Note. This plugin does not change behavior of close from the menu.
 keepzotero-cb_enable_ctrl_w = 
     .label = Change Ctrl/Command + W shortcut to to minimize
 keepzotero-gb_win_linux_only = The followings only have effect on Windows/Linux

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "KeepZotero",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Keep Zotero from accidental close",
 	"homepage_url": "https://github.com/yhmtsai/KeepZotero",
 	"applications": {

--- a/preferences.xhtml
+++ b/preferences.xhtml
@@ -6,6 +6,7 @@
 	<groupbox>
     <label><html:h2 data-l10n-id="keepzotero-preferences"></html:h2></label>
     <description data-l10n-id="keepzotero-note"></description>
+    <checkbox id="id-keepzotero-cb_minimize_on_button" data-l10n-id="keepzotero-cb_minimize_on_button" preference="extensions.keepzotero.cb_minimize_on_button"/>
     <checkbox id="id-keepzotero-cb_check_exit" data-l10n-id="keepzotero-cb_check_exit" preference="extensions.keepzotero.cb_check_exit"/>
     <checkbox id="id-keepzotero-cb_enable_ctrl_w" data-l10n-id="keepzotero-cb_enable_ctrl_w" preference="extensions.keepzotero.cb_enable_ctrl_w"/>
     <groupbox> 

--- a/prefs.js
+++ b/prefs.js
@@ -1,3 +1,4 @@
+pref("extensions.keepzotero.cb_minimize_on_button", true);
 pref("extensions.keepzotero.cb_check_exit", true);
 pref("extensions.keepzotero.cb_enable_ctrl_w", true);
 pref("extensions.keepzotero.cb_enable_alt_f4", true);


### PR DESCRIPTION
After this PR (0.2.0), this plugin can change the behavior of close button of the title bar to minimize the window.
This should complete the missing part of normal way to closing Zotero in #6 .

Another way to do it is to overwrite the close method. It should handle more cases than the button, but it is more risky.
For example, more than one function overwrite and restore the close such that the close function state is unclear anymore. 

This also bump the version to v0.2.0